### PR TITLE
avoid broken link

### DIFF
--- a/capcomposer/src/capcomposer/config/templates/breadcrumbs_include.html
+++ b/capcomposer/src/capcomposer/config/templates/breadcrumbs_include.html
@@ -3,8 +3,8 @@
         <nav class="breadcrumb" aria-label="breadcrumbs" style="overflow: hidden">
             <ul>
                 {% for page in self.get_ancestors %}
-                    {% if page.is_root == False %}
-                        <li><a href={{ page.url }}> {{ page.title }}</a></li>
+                    {% if page.is_root == False and page.url %}
+                        <li><a href="{{ page.url }}"> {{ page.title }}</a></li>
                     {% endif %}
                 {% endfor %}
                 <li class=”active”><b style="padding-left: 8px"> {{ self.title }}</b></li>


### PR DESCRIPTION
Avoiding broken links when standalone CAP Composer is used for a single country with a single root_url